### PR TITLE
Add config option to set wait time for `system_obj:wait` instead of constant time

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ This is a Neovim plugin for Unity
         vim.keymap.set('n', '<F5>', function()
             if dap.session() == nil then
                 local unity = require('unity')
+                unity.setup({
+                    discover_time = 2000 -- default option
+                })
                 -- vstuc
                 dap.adapters.vstuc = unity.vstuc_dap_adapter()
                 dap.configurations.cs = unity.vstuc_dap_configuration()

--- a/lua/unity.lua
+++ b/lua/unity.lua
@@ -1,4 +1,5 @@
 ﻿local M = {}
+M._config = { discover_time = 2000 }
 
 local function find_path(target)
 	local path = vim.fn.expand('%:p')
@@ -91,7 +92,7 @@ local function unity_attach_probs()
 	local system_obj = vim.system(
 		{ 'dotnet', vstuc_path() .. '/extension/bin/UnityAttachProbe.dll' },
 		{ text = true, stdin = true })
-	local completed = system_obj:wait(2000)
+	local completed = system_obj:wait(M._config.discover_time)
 	local stdout = completed.stdout
 	if stdout == nil or #stdout == 0 then
 		print('No endpoint found (is unity running?)')
@@ -118,7 +119,9 @@ local function unity_attach_probs()
 	vim.notify('done.')
 	return probs
 end
-function M.setup()
+function M.setup(config)
+	config = config or {}
+	M._config = vim.tbl_extend('force', M._config, config)
 	local functionTbl = {
 		'Refresh',
 		'Play',


### PR DESCRIPTION
UnityAttachProbe.dll will take more time to generate any output when multiple unity player running in different computer which are connected to same LAN. With default `2second` wait time it will fail to discover any process because of this not able to connect to debugger.

Now, config can be passed to `setup()` to override default `2000` wait time